### PR TITLE
Fixed file path sanitization.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if (NOT EXISTS "${_CSM_COMPONENTS_CORE_INCLUDE_DIR}/Live2DCubismCore.h")
 endif ()
 
 # Make sure OpenGL header is valid if required.
-if (_CSM_COMPONENTS_GL_H AND NOT EXISTS ${_CSM_COMPONENTS_GL_H})
+if (_CSM_COMPONENTS_GL_H AND (NOT EXISTS ${_CSM_COMPONENTS_GL_H} OR IS_DIRECTORY ${_CSM_COMPONENTS_GL_H}))
   message(FATAL_ERROR "[Live2D Cubism Components] OpenGL header not found.")
 endif ()
 


### PR DESCRIPTION
If user leaves CSM_COMPONENTS_GL_H empty, _CSM_COMPONENTS_GL_H will expands to CMAKE_CURRENT_LIST_DIR and always exists.

Anyway, we expect file, not directory.