### PR TITLE
raspberry pi 3 gles2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CSM_COMPONENTS_CORE_INCLUDE_DIRECTORY "../Core/include" CACHE STRING "Path t
 option(CSM_COMPONENTS_BUILD_GL_RENDERER "Enables OpenGL reference renderer." OFF)
 
 # Path to OpenGL header on desktop.
-if (NOT ANDROID AND NOT EMSCRIPTEN AND NOT IOS)
+if (NOT ANDROID AND NOT EMSCRIPTEN AND NOT IOS AND NOT RPI)
   set(CSM_COMPONENTS_GL_H "" CACHE STRING "Path to OpenGL header.")
 endif ()
 
@@ -57,7 +57,7 @@ endif ()
 
 
 # Detect desktop.
-if (NOT ANDROID AND NOT EMSCRIPTEN AND NOT IOS)
+if (NOT ANDROID AND NOT EMSCRIPTEN AND NOT IOS AND NOT RPI)
   set(_CSM_COMPONENTS_DESKTOP ON)
 endif ()
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -27,7 +27,7 @@ endif ()
 
 
 # Detect desktop.
-if (NOT ANDROID AND NOT IOS AND NOT EMSCRIPTEN)
+if (NOT ANDROID AND NOT IOS AND NOT EMSCRIPTEN AND NOT RPI)
   set(_DESKTOP ON)
 endif ()
 

--- a/sample/src/App.c
+++ b/sample/src/App.c
@@ -130,7 +130,11 @@ int main(int argumentCount, char *arguments[])
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
 #endif
+#if _RPI
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_EGL, SDL_GL_CONTEXT_PROFILE_ES);
+#else
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
+#endif
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, SDL_TRUE);
 
 
@@ -183,8 +187,9 @@ int main(int argumentCount, char *arguments[])
   
 
   // Loop.
+#if !_RPI
 	SDL_GL_SetSwapInterval(1);
-
+#endif
 
 	lastCounter = SDL_GetPerformanceCounter();
 	exitLoop = 0;


### PR DESCRIPTION
ソフトウェアレンダリングだとラズパイ3で同梱されているサンプルのこはるが13fps、  
テクスチャを512*512に縮小しても17fps程度でした。  
gles2.0に変更すると60fps程度出ることが確認できましたのでプルリクを出しておきます。  
RPIの定義などはうまく整合性を付けて取り込んでいただければと思います。  